### PR TITLE
[F] Fix line break in spoiler

### DIFF
--- a/src/main/kotlin/org/hydev/back/controller/CommentController.kt
+++ b/src/main/kotlin/org/hydev/back/controller/CommentController.kt
@@ -91,7 +91,7 @@ class CommentController(
 
         // Spoiler
         if (callbackQuery.data == "comment-pass-spoiler")
-            comment.content = "||${comment.content.replace('\n', ' ')}||"
+            comment.content = "||${comment.content}||"
 
         // Create commit content
         val fPath = "people/${comment.personId}/comments/${date("yyyy-MM-dd")}-C${comment.id}.json"


### PR DESCRIPTION
前端页面可以处理 spoiler 中的换行
不需要将换行转化为空格;
在此处转换可能造成观感较差

![image](https://github.com/one-among-us/backend/assets/64070144/f4aee444-a6f7-4e87-a8f2-fb84a50577e8)
