### PR TITLE
[+] Add /note command

### DIFF
--- a/src/main/kotlin/org/hydev/back/Application.kt
+++ b/src/main/kotlin/org/hydev/back/Application.kt
@@ -1,6 +1,5 @@
 package org.hydev.back
 
-import com.github.kittinunf.fuel.httpGet
 import com.github.kotlintelegrambot.Bot
 import com.github.kotlintelegrambot.bot
 import com.github.kotlintelegrambot.dispatch
@@ -8,7 +7,9 @@ import com.github.kotlintelegrambot.dispatcher.Dispatcher
 import com.github.kotlintelegrambot.dispatcher.callbackQuery
 import com.github.kotlintelegrambot.entities.ChatId
 import com.github.kotlintelegrambot.logging.LogLevel
-import kotlinx.coroutines.*
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.hydev.back.ai.getMorningMsg
 import org.hydev.back.controller.CommentController
 import org.hydev.back.db.Ban
@@ -17,8 +18,6 @@ import org.hydev.back.geoip.GeoIP
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.stereotype.Component
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import javax.annotation.PostConstruct
 
 val secrets = getSecrets()
@@ -83,23 +82,16 @@ class PostConstruct(
 					"Banned IPs:\n" + banRepo.findAll().joinToString("\n") { it.ip }
 				}
 				secureCmd("note") {
-					val replyTo = message.replyToMessage
-					if (replyTo == null) {
-						return@secureCmd "Please reply to a pending comment to use this command"
-					}
+					val replyTo = message.replyToMessage ?: return@secureCmd "Please reply to a pending comment to use this command"
 
+					
 					val text = replyTo.text ?: return@secureCmd "Cannot read original message content"
-					val idMatch = COMMENT_ID_REGEX.find(text)
-					if (idMatch == null) {
-						return@secureCmd "Cannot extract comment ID from message"
-					}
+					val idMatch = COMMENT_ID_REGEX.find(text) ?: return@secureCmd "Cannot extract comment ID from message"
 
 					val commentId = idMatch.groupValues[1].toLong()
 
 					val noteContent = (message.text ?: "").substringAfter("/note").trim()
-					if (noteContent.isEmpty()) {
-						return@secureCmd "Usage: /note <note> or /note clear"
-					}
+						.ifBlank { null } ?: return@secureCmd "Usage: /note <note> or /note clear"
 
 					commentController.addNote(commentId, noteContent)
 				}

--- a/src/main/kotlin/org/hydev/back/controller/CommentController.kt
+++ b/src/main/kotlin/org/hydev/back/controller/CommentController.kt
@@ -46,14 +46,11 @@ class CommentController(
             ?: return "找不到评论 #$commentId"
 
         if (noteContent.lowercase() == "clear") {
-            comment.note = null
-            commentRepo.save(comment)
+            commentRepo.save(comment.apply { note = null })
             return "✅ 已清空评论 #$commentId 的备注"
         }
 
-        comment.note = noteContent
-        commentRepo.save(comment)
-
+        commentRepo.save(comment.apply { note = noteContent })
         return "✅ 已为评论 #$commentId 添加备注：\n$noteContent"
     }
 
@@ -120,15 +117,9 @@ class CommentController(
         val cMsg = "[+] Comment added by ${comment.submitter} for ${comment.personId}"
 
         // Build JSON content with optional replies
-        val content = buildList {
-            add("id" to comment.id)
-            add("content" to comment.content)
-            add("submitter" to comment.submitter)
-            add("date" to comment.date)
-            if (comment.note != null) {
-                add("replies" to listOf(mapOf("content" to comment.note, "submitter" to "Maintainer")))
-            }
-        }.let { json(*it.toTypedArray()) }
+        val content = json("id" to comment.id, "content" to comment.content,
+            "submitter" to comment.submitter, "date" to comment.date,
+            *comment.note?.let { arrayOf("replies" to listOf(mapOf("content" to it, "submitter" to "Maintainer"))) } ?: arrayOf())
         println("[+] Comment approved. Adding Comment $id: $content")
 
         // Write commit

--- a/src/main/kotlin/org/hydev/back/db/PendingComment.kt
+++ b/src/main/kotlin/org/hydev/back/db/PendingComment.kt
@@ -26,7 +26,10 @@ data class PendingComment(
     var email: str = "",
     var date: Date = Date(0),
     var approved: bool = false,
-    var ip: str = ""
+    var ip: str = "",
+
+    @Type(type = "text")
+    var note: str? = null
 )
 {
     override fun equals(other: Any?): Boolean


### PR DESCRIPTION
添加 /note 命令，对待处理评论回复 `/note <内容>`可以添加评论，submitter当前固定为`Maintainer`。

使用`/note clear`命令可以取消对待处理评论的回复。

对数据库的更改是`pending_comment`表新增`note`(`longtext`)，此前已设置`spring.jpa.hibernate.ddl-auto=update`所以可以自动更新

可能待改进：

- 记录评论人？
- 目前不能转换telegram消息格式为markdown，如需使用markdown标记需要评论者手动格式化并按原样发送